### PR TITLE
Feature/login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    all {
+        exclude group: 'ch.qos.logback', module: 'logback-classic'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
+    }
 }
 
 repositories {
@@ -45,7 +49,6 @@ bootJar {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -54,6 +57,20 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     // swagger API
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
+    //Oauth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    //H2 DB
+    runtimeOnly 'com.h2database:h2:1.4.200'
+    // Configuration
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/checkmate/backend/BackendApplication.java
+++ b/src/main/java/com/checkmate/backend/BackendApplication.java
@@ -2,8 +2,16 @@ package com.checkmate.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import com.checkmate.backend.oauth.config.AppProperties;
+import com.checkmate.backend.oauth.config.CorsProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties({
+	CorsProperties.class,
+	AppProperties.class
+})
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/checkmate/backend/advice/ExceptionAdvice.java
+++ b/src/main/java/com/checkmate/backend/advice/ExceptionAdvice.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.checkmate.backend.advice.exception.LoginFailedException;
+import com.checkmate.backend.advice.exception.OAuthProviderMissMatchException;
+import com.checkmate.backend.advice.exception.TokenValidFailedException;
 import com.checkmate.backend.common.CommonResult;
 import com.checkmate.backend.service.ResponseService;
 
@@ -38,5 +40,18 @@ public class ExceptionAdvice {
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	protected CommonResult loginFailedException(HttpServletRequest request, LoginFailedException e) {
 		return responseService.getFailResult(HttpStatus.INTERNAL_SERVER_ERROR.value(), "로그인 실패했습니다.");
+	}
+
+	@ExceptionHandler(TokenValidFailedException.class)
+	@ResponseStatus(HttpStatus.NOT_ACCEPTABLE)
+	protected CommonResult tokenValidFailedException(HttpServletRequest request, TokenValidFailedException e) {
+		return responseService.getFailResult(HttpStatus.NOT_ACCEPTABLE.value(), "토큰 만들기 실패.");
+	}
+
+	@ExceptionHandler(OAuthProviderMissMatchException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	protected CommonResult oAuthProviderMissMatchException(HttpServletRequest request,
+		OAuthProviderMissMatchException e) {
+		return responseService.getFailResult(HttpStatus.INTERNAL_SERVER_ERROR.value(), "");
 	}
 }

--- a/src/main/java/com/checkmate/backend/advice/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/checkmate/backend/advice/RestAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package com.checkmate.backend.advice;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException, ServletException {
+		authException.printStackTrace();
+		log.info("Responding with unauthorized error. Message := {}", authException.getMessage());
+		response.sendError(
+			HttpServletResponse.SC_UNAUTHORIZED,
+			authException.getLocalizedMessage()
+		);
+	}
+}

--- a/src/main/java/com/checkmate/backend/advice/exception/OAuthProviderMissMatchException.java
+++ b/src/main/java/com/checkmate/backend/advice/exception/OAuthProviderMissMatchException.java
@@ -1,0 +1,11 @@
+package com.checkmate.backend.advice.exception;
+
+public class OAuthProviderMissMatchException extends RuntimeException {
+	public OAuthProviderMissMatchException() {
+		super();
+	}
+
+	public OAuthProviderMissMatchException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/checkmate/backend/advice/exception/TokenValidFailedException.java
+++ b/src/main/java/com/checkmate/backend/advice/exception/TokenValidFailedException.java
@@ -1,0 +1,10 @@
+package com.checkmate.backend.advice.exception;
+
+public class TokenValidFailedException extends RuntimeException {
+	public TokenValidFailedException() {
+	}
+
+	public TokenValidFailedException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/checkmate/backend/config/Swagger2Config.java
+++ b/src/main/java/com/checkmate/backend/config/Swagger2Config.java
@@ -1,11 +1,17 @@
 package com.checkmate.backend.config;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 /**
  * @package : com.checkmate.backend.config
@@ -30,8 +36,21 @@ public class Swagger2Config {
 	@Bean
 	public OpenAPI springShopOpenAPI() {
 		return new OpenAPI()
+			.components(new Components()
+				.addSecuritySchemes("bearer-key",
+					new SecurityScheme()
+						.type(SecurityScheme.Type.HTTP)
+						.scheme("bearer")
+						.bearerFormat("JWT")
+				)
+			)
 			.info(new Info().title("CheckMate API")
 				.description("CheckMate API 명세서입니다.")
-				.version("v0.0.1"));
+				.version("v0.0.1"))
+			.addSecurityItem(
+				new SecurityRequirement()
+					.addList("bearer-jwt", Arrays.asList("read", "write"))
+					.addList("bearer-key", Collections.emptyList())
+			);
 	}
 }

--- a/src/main/java/com/checkmate/backend/oauth/api/controller/AuthController.java
+++ b/src/main/java/com/checkmate/backend/oauth/api/controller/AuthController.java
@@ -1,0 +1,171 @@
+package com.checkmate.backend.oauth.api.controller;
+
+import java.util.Date;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.checkmate.backend.advice.exception.TokenValidFailedException;
+import com.checkmate.backend.common.SingleResult;
+import com.checkmate.backend.oauth.api.entity.UserRefreshToken;
+import com.checkmate.backend.oauth.api.repo.UserRefreshTokenRepository;
+import com.checkmate.backend.oauth.config.AppProperties;
+import com.checkmate.backend.oauth.entity.RoleType;
+import com.checkmate.backend.oauth.entity.UserPrincipal;
+import com.checkmate.backend.oauth.model.AuthReqModel;
+import com.checkmate.backend.oauth.token.AuthToken;
+import com.checkmate.backend.oauth.token.AuthTokenProvider;
+import com.checkmate.backend.oauth.util.CookieUtil;
+import com.checkmate.backend.oauth.util.HeaderUtil;
+import com.checkmate.backend.service.ResponseService;
+
+import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : com.checkmate.backend.oauth.api.controller
+ * @name: AuthController.java
+ * @date : 2022/05/23 2:10 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : OAuth2를 처리하는 Controller
+ * @modified :
+ **/
+@Tag(name = "OAuth2", description = "로그인 관련 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final static long THREE_DAYS_MSEC = 259200000;
+	private final static String REFRESH_TOKEN = "refresh_token";
+	private final AppProperties appProperties;
+	private final AuthTokenProvider tokenProvider;
+	private final AuthenticationManager authenticationManager;
+	private final UserRefreshTokenRepository userRefreshTokenRepository;
+	private final ResponseService responseService;
+
+	@PostMapping("/login")
+	public SingleResult<String> login(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		@RequestBody AuthReqModel authReqModel
+	) {
+		Authentication authentication = authenticationManager.authenticate(
+			new UsernamePasswordAuthenticationToken(
+				authReqModel.getId(),
+				authReqModel.getPassword()
+			)
+		);
+
+		String userId = authReqModel.getId();
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		Date now = new Date();
+		AuthToken accessToken = tokenProvider.createAuthToken(
+			userId,
+			((UserPrincipal)authentication.getPrincipal()).getRoleType().getCode(),
+			new Date(now.getTime() + appProperties.getAuth().getTokenExpiry())
+		);
+
+		long refreshTokenExpiry = appProperties.getAuth().getRefreshTokenExpiry();
+		AuthToken refreshToken = tokenProvider.createAuthToken(
+			appProperties.getAuth().getTokenSecret(),
+			new Date(now.getTime() + refreshTokenExpiry)
+		);
+
+		// userId refresh token 으로 DB 확인
+		UserRefreshToken userRefreshToken = userRefreshTokenRepository.findByUserId(userId);
+		if (userRefreshToken == null) {
+			// 없는 경우 새로 등록
+			userRefreshToken = new UserRefreshToken(userId, refreshToken.getToken());
+			userRefreshTokenRepository.saveAndFlush(userRefreshToken);
+		} else {
+			// DB에 refresh 토큰 업데이트
+			userRefreshToken.setRefreshToken(refreshToken.getToken());
+		}
+
+		int cookieMaxAge = (int)refreshTokenExpiry / 60;
+		CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+		CookieUtil.addCookie(response, REFRESH_TOKEN, refreshToken.getToken(), cookieMaxAge);
+
+		return responseService.getSingleResult(accessToken.getToken());
+	}
+
+	@GetMapping("/refresh")
+	public SingleResult<String> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+		// access token 확인
+		String accessToken = HeaderUtil.getAccessToken(request);
+		AuthToken authToken = tokenProvider.convertAuthToken(accessToken);
+		if (!authToken.validate()) {
+			throw new TokenValidFailedException();
+		}
+
+		// expired access token 인지 확인
+		Claims claims = authToken.getExpiredTokenClaims();
+		if (claims == null) {
+			throw new TokenValidFailedException("유효한 access token.");
+		}
+
+		String userId = claims.getSubject();
+		RoleType roleType = RoleType.of(claims.get("role", String.class));
+
+		// refresh token
+		String refreshToken = CookieUtil.getCookie(request, REFRESH_TOKEN)
+			.map(Cookie::getValue)
+			.orElse((null));
+		AuthToken authRefreshToken = tokenProvider.convertAuthToken(refreshToken);
+
+		if (authRefreshToken.validate()) {
+			throw new TokenValidFailedException("refresh Token 유효하지 않음.");
+		}
+
+		// userId refresh token 으로 DB 확인
+		UserRefreshToken userRefreshToken = userRefreshTokenRepository.findByUserIdAndRefreshToken(userId,
+			refreshToken);
+		if (userRefreshToken == null) {
+			throw new TokenValidFailedException("refresh Token 유효하지 않음.");
+		}
+
+		Date now = new Date();
+		AuthToken newAccessToken = tokenProvider.createAuthToken(
+			userId,
+			roleType.getCode(),
+			new Date(now.getTime() + appProperties.getAuth().getTokenExpiry())
+		);
+
+		long validTime = authRefreshToken.getTokenClaims().getExpiration().getTime() - now.getTime();
+
+		// refresh 토큰 기간이 3일 이하로 남은 경우, refresh 토큰 갱신
+		if (validTime <= THREE_DAYS_MSEC) {
+			// refresh 토큰 설정
+			long refreshTokenExpiry = appProperties.getAuth().getRefreshTokenExpiry();
+
+			authRefreshToken = tokenProvider.createAuthToken(
+				appProperties.getAuth().getTokenSecret(),
+				new Date(now.getTime() + refreshTokenExpiry)
+			);
+
+			// DB에 refresh 토큰 업데이트
+			userRefreshToken.setRefreshToken(authRefreshToken.getToken());
+
+			int cookieMaxAge = (int)refreshTokenExpiry / 60;
+			CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+			CookieUtil.addCookie(response, REFRESH_TOKEN, authRefreshToken.getToken(), cookieMaxAge);
+		}
+
+		return responseService.getSingleResult(newAccessToken.getToken());
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/api/controller/UserController.java
+++ b/src/main/java/com/checkmate/backend/oauth/api/controller/UserController.java
@@ -1,0 +1,62 @@
+package com.checkmate.backend.oauth.api.controller;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.checkmate.backend.common.SingleResult;
+import com.checkmate.backend.oauth.api.entity.User;
+import com.checkmate.backend.oauth.model.UserDto;
+import com.checkmate.backend.oauth.service.UserService;
+import com.checkmate.backend.service.ResponseService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @package : com.checkmate.backend.oauth.api.controller
+ * @name: UserController.java
+ * @date : 2022/05/23 2:15 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 사용자 관리 Controller
+ * @modified :
+ **/
+@Tag(name = "user", description = "유저관리 API")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+
+	private final UserService userService;
+	private final ResponseService responseService;
+
+	@Operation(summary = "유저 정보 조회", description = "로그인한 유저의 정보를 조회합니다", security = {
+		@SecurityRequirement(name = "bearer-key")})
+	@GetMapping
+	public SingleResult<User> getUser() {
+		org.springframework.security.core.userdetails.User principal = (org.springframework.security.core.userdetails.User)SecurityContextHolder
+			.getContext().getAuthentication().getPrincipal();
+
+		User user = userService.getUser(principal.getUsername());
+
+		return responseService.getSingleResult(user);
+	}
+
+	//회원가입 로직 추가 필요
+	@Operation(summary = "회원가입", description = "회원가입 요청")
+	@PostMapping("/join")
+	public SingleResult<User> join(@RequestBody @Parameter(description = "회원가입 정보", required = true) UserDto user) {
+		log.info("회원가입 - {}", user);
+		User signedUser = userService.signUpUser(user);
+		return responseService.getSingleResult(signedUser);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/api/entity/User.java
+++ b/src/main/java/com/checkmate/backend/oauth/api/entity/User.java
@@ -1,0 +1,90 @@
+package com.checkmate.backend.oauth.api.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.checkmate.backend.oauth.entity.ProviderType;
+import com.checkmate.backend.oauth.entity.RoleType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "USER")
+public class User {
+	@JsonIgnore
+	@Id
+	@Column(name = "USER_SEQ")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long userSeq;
+
+	@Column(name = "USER_ID", length = 64, unique = true)
+	@NotNull
+	@Size(max = 64)
+	private String userId;
+
+	@Column(name = "USERNAME", length = 100)
+	@NotNull
+	@Size(max = 100)
+	private String username;
+
+	@JsonIgnore
+	@Column(name = "PASSWORD", length = 128)
+	@NotNull
+	@Size(max = 128)
+	private String password;
+
+	@Column(name = "PROVIDER_TYPE", length = 20)
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private ProviderType providerType;
+
+	@Column(name = "ROLE_TYPE", length = 20)
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private RoleType roleType;
+
+	@Column(name = "CREATED_AT")
+	@NotNull
+	private LocalDateTime createdAt;
+
+	@Column(name = "MODIFIED_AT")
+	@NotNull
+	private LocalDateTime modifiedAt;
+
+	public User(
+		@NotNull @Size(max = 64) String userId,
+		@NotNull @Size(max = 100) String username,
+		@NotNull @Size(max = 128) String password,
+		@NotNull ProviderType providerType,
+		@NotNull RoleType roleType,
+		@NotNull LocalDateTime createdAt,
+		@NotNull LocalDateTime modifiedAt
+	) {
+		this.userId = userId;
+		this.username = username;
+		this.password = password;
+		this.providerType = providerType;
+		this.roleType = roleType;
+		this.createdAt = createdAt;
+		this.modifiedAt = modifiedAt;
+	}
+
+}

--- a/src/main/java/com/checkmate/backend/oauth/api/entity/UserRefreshToken.java
+++ b/src/main/java/com/checkmate/backend/oauth/api/entity/UserRefreshToken.java
@@ -1,0 +1,49 @@
+package com.checkmate.backend.oauth.api.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "USER_REFRESH_TOKEN")
+public class UserRefreshToken {
+	@JsonIgnore
+	@Id
+	@Column(name = "REFRESH_TOKEN_SEQ")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long refreshTokenSeq;
+
+	@Column(name = "USER_ID", length = 64, unique = true)
+	@NotNull
+	@Size(max = 64)
+	private String userId;
+
+	@Column(name = "REFRESH_TOKEN", length = 256)
+	@NotNull
+	@Size(max = 256)
+	private String refreshToken;
+
+	public UserRefreshToken(
+		@NotNull @Size(max = 64) String userId,
+		@NotNull @Size(max = 256) String refreshToken
+	) {
+		this.userId = userId;
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/api/repo/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/src/main/java/com/checkmate/backend/oauth/api/repo/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -1,0 +1,70 @@
+package com.checkmate.backend.oauth.api.repo;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import com.checkmate.backend.oauth.util.CookieUtil;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
+/**
+ * @package : com.checkmate.backend.oauth.api.repo
+ * @name: OAuth2AuthorizationRequestBasedOnCookieRepository.java
+ * @date : 2022/05/23 1:34 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : authorization request를 cookie에 save 및 retireve 하기위해 사용
+ * @modified :
+ **/
+public class OAuth2AuthorizationRequestBasedOnCookieRepository implements
+	AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+	public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+	public final static String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+	public final static String REFRESH_TOKEN = "refresh_token";
+	private final static int cookieExpireSeconds = 180;
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+			.map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+			.orElse(null);
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+		HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+			CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+			CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+			return;
+		}
+
+		CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+			CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+		if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+			CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+		}
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+		return this.loadAuthorizationRequest(request);
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+		HttpServletResponse response) {
+		return this.loadAuthorizationRequest(request);
+	}
+
+	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+		CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+		CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/api/repo/UserRefreshTokenRepository.java
+++ b/src/main/java/com/checkmate/backend/oauth/api/repo/UserRefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.checkmate.backend.oauth.api.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.checkmate.backend.oauth.api.entity.UserRefreshToken;
+
+public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+	UserRefreshToken findByUserId(String userId);
+
+	UserRefreshToken findByUserIdAndRefreshToken(String userId, String refreshToken);
+}

--- a/src/main/java/com/checkmate/backend/oauth/api/repo/UserRepository.java
+++ b/src/main/java/com/checkmate/backend/oauth/api/repo/UserRepository.java
@@ -1,0 +1,11 @@
+package com.checkmate.backend.oauth.api.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.checkmate.backend.oauth.api.entity.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+	User findByUserId(String userId);
+}

--- a/src/main/java/com/checkmate/backend/oauth/config/AppProperties.java
+++ b/src/main/java/com/checkmate/backend/oauth/config/AppProperties.java
@@ -1,0 +1,51 @@
+package com.checkmate.backend.oauth.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @package : com.checkmate.backend.oauth.config
+ * @name: AppProperties.java
+ * @date : 2022/05/23 1:47 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 정의한 토큰 정보를 자바 코드에서 가져다 쓰기 위함
+ * @modified :
+ **/
+@Getter
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+
+	private final Auth auth = new Auth();
+	private final OAuth2 oauth2 = new OAuth2();
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Auth {
+		private String tokenSecret;
+		private long tokenExpiry;
+		private long refreshTokenExpiry;
+	}
+
+	public static final class OAuth2 {
+		private List<String> authorizedRedirectUris = new ArrayList<>();
+
+		public List<String> getAuthorizedRedirectUris() {
+			return authorizedRedirectUris;
+		}
+
+		public OAuth2 authorizedRedirectUris(List<String> authorizedRedirectUris) {
+			this.authorizedRedirectUris = authorizedRedirectUris;
+			return this;
+		}
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/config/CorsProperties.java
+++ b/src/main/java/com/checkmate/backend/oauth/config/CorsProperties.java
@@ -1,0 +1,16 @@
+package com.checkmate.backend.oauth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+	private String allowedOrigins;
+	private String allowedMethods;
+	private String allowedHeaders;
+	private Long maxAge;
+}

--- a/src/main/java/com/checkmate/backend/oauth/config/JwtConfig.java
+++ b/src/main/java/com/checkmate/backend/oauth/config/JwtConfig.java
@@ -1,0 +1,27 @@
+package com.checkmate.backend.oauth.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.checkmate.backend.oauth.token.AuthTokenProvider;
+
+/**
+ * @package : com.checkmate.backend.oauth.config
+ * @name: JwtConfig.java
+ * @date : 2022/05/22 5:38 오후
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : Jwt을 사용하기 위한 설정
+ * @modified :
+ **/
+@Configuration
+public class JwtConfig {
+	@Value("${jwt.secret}")
+	private String secret;
+
+	@Bean
+	public AuthTokenProvider jwtProvider() {
+		return new AuthTokenProvider(secret);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/checkmate/backend/oauth/config/SecurityConfig.java
@@ -1,0 +1,190 @@
+package com.checkmate.backend.oauth.config;
+
+import java.util.Arrays;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.checkmate.backend.advice.RestAuthenticationEntryPoint;
+import com.checkmate.backend.oauth.api.repo.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.checkmate.backend.oauth.api.repo.UserRefreshTokenRepository;
+import com.checkmate.backend.oauth.filter.TokenAuthenticationFilter;
+import com.checkmate.backend.oauth.handler.OAuth2AuthenticationFailureHandler;
+import com.checkmate.backend.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import com.checkmate.backend.oauth.handler.TokenAccessDeniedHandler;
+import com.checkmate.backend.oauth.service.CustomOAuth2UserService;
+import com.checkmate.backend.oauth.service.CustomUserDetailService;
+import com.checkmate.backend.oauth.token.AuthTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : com.checkmate.backend.oauth.config
+ * @name: SecurityConfig.java
+ * @date : 2022/05/23 1:51 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : Spring security를 위한 설정 파일
+ * @modified :
+ **/
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	private final CorsProperties corsProperties;
+	private final AppProperties appProperties;
+	private final AuthTokenProvider tokenProvider;
+	private final CustomUserDetailService userDetailsService;
+	private final CustomOAuth2UserService oAuth2UserService;
+	private final TokenAccessDeniedHandler tokenAccessDeniedHandler;
+	private final UserRefreshTokenRepository userRefreshTokenRepository;
+
+	/*
+	 * UserDetailsService 설정
+	 * */
+	@Override
+	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+		auth.userDetailsService(userDetailsService)
+			.passwordEncoder(passwordEncoder());
+	}
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http.
+			headers().frameOptions().sameOrigin()
+			// .and()
+			// .headers().httpStrictTransportSecurity().disable()
+			.and()
+			// .cors()//cors 허용
+			// .and()
+			.sessionManagement() // session Creation Policy를 STATELESS로 정의해 session을 사용하지 않겠다 선언
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			//REST API 이기 떄문에 사용 x
+			.csrf().disable()
+			.formLogin().disable()
+			.httpBasic().disable()
+			.exceptionHandling()
+			// 사용자가 authentication 없이 protected resource에 접근하는 경우에 invoked 되는 entry point
+			.authenticationEntryPoint(new RestAuthenticationEntryPoint())
+			//인가되지않은 사용자 Handler
+			.accessDeniedHandler(tokenAccessDeniedHandler)
+			.and()
+			// 경로 허용 경우 설정
+			.authorizeRequests()
+			// .requestMatchers().permitAll()
+			// .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+			.antMatchers("/**", "/h2-console/**").permitAll()
+			// .antMatchers("/api/**","**/oauth/**").permitAll()
+			// .antMatchers("/api/**").hasAnyAuthority(RoleType.USER.getCode())
+			// .antMatchers("/api/**/admin/**").hasAnyAuthority(RoleType.ADMIN.getCode())
+			// .anyRequest().authenticated()
+			.and()
+			//OAuth2 로그인 설정 부분
+			.oauth2Login()
+			// oauth 로그인시 접근할 end point를 정의합니다
+			.authorizationEndpoint()
+			.baseUri("/oauth2/authorization")
+			.authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository())
+			.and()
+			.redirectionEndpoint()
+			.baseUri("/*/oauth2/code/*")
+			.and()
+			// 로그인시 사용할 User Service를 정의
+			.userInfoEndpoint()
+			.userService(oAuth2UserService)
+			.and()
+			//성공 실패 Handler
+			.successHandler(oAuth2AuthenticationSuccessHandler())
+			.failureHandler(oAuth2AuthenticationFailureHandler());
+
+		//reqeust 요청이 올때마다 UsernamePasswordAuthenticationFilter 이전에 tokenAuthenticaitonFilter를 수행하도록 정의
+		http.addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+	}
+
+	/*
+	 * auth 매니저 설정
+	 * */
+	@Override
+	@Bean(BeanIds.AUTHENTICATION_MANAGER)
+	protected AuthenticationManager authenticationManager() throws Exception {
+		return super.authenticationManager();
+	}
+
+	/*
+	 * security 설정 시, 사용할 인코더 설정
+	 * */
+	@Bean
+	public BCryptPasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	/*
+	 * 토큰 필터 설정
+	 * */
+	@Bean
+	public TokenAuthenticationFilter tokenAuthenticationFilter() {
+		return new TokenAuthenticationFilter(tokenProvider);
+	}
+
+	/*
+	 * 쿠키 기반 인가 Repository
+	 * 인가 응답을 연계 하고 검증할 때 사용.
+	 * */
+	@Bean
+	public OAuth2AuthorizationRequestBasedOnCookieRepository oAuth2AuthorizationRequestBasedOnCookieRepository() {
+		return new OAuth2AuthorizationRequestBasedOnCookieRepository();
+	}
+
+	/*
+	 * Oauth 인증 성공 핸들러
+	 * */
+	@Bean
+	public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
+		return new OAuth2AuthenticationSuccessHandler(
+			tokenProvider,
+			appProperties,
+			userRefreshTokenRepository,
+			oAuth2AuthorizationRequestBasedOnCookieRepository()
+		);
+	}
+
+	/*
+	 * Oauth 인증 실패 핸들러
+	 * */
+	@Bean
+	public OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
+		return new OAuth2AuthenticationFailureHandler(oAuth2AuthorizationRequestBasedOnCookieRepository());
+	}
+
+	/*
+	 * Cors 설정
+	 * */
+	@Bean
+	public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+		UrlBasedCorsConfigurationSource corsConfigSource = new UrlBasedCorsConfigurationSource();
+
+		CorsConfiguration corsConfig = new CorsConfiguration();
+		corsConfig.setAllowedHeaders(Arrays.asList(corsProperties.getAllowedHeaders().split(",")));
+		corsConfig.setAllowedMethods(Arrays.asList(corsProperties.getAllowedMethods().split(",")));
+		corsConfig.setAllowedOrigins(Arrays.asList(corsProperties.getAllowedOrigins().split(",")));
+		corsConfig.addAllowedOrigin("http://localhost:8080/h2-console");
+		corsConfig.addAllowedOrigin("http://localhost:8080/h2-console/**");
+		corsConfig.addAllowedOrigin("http://localhost:3000");
+		corsConfig.setAllowCredentials(true);
+		corsConfig.setMaxAge(corsConfig.getMaxAge());
+
+		corsConfigSource.registerCorsConfiguration("/**", corsConfig);
+		return corsConfigSource;
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/entity/ProviderType.java
+++ b/src/main/java/com/checkmate/backend/oauth/entity/ProviderType.java
@@ -1,0 +1,11 @@
+package com.checkmate.backend.oauth.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ProviderType {
+	GOOGLE,
+	NAVER,
+	KAKAO,
+	LOCAL;
+}

--- a/src/main/java/com/checkmate/backend/oauth/entity/RoleType.java
+++ b/src/main/java/com/checkmate/backend/oauth/entity/RoleType.java
@@ -1,0 +1,24 @@
+package com.checkmate.backend.oauth.entity;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RoleType {
+	USER("ROLE_USER", "일반 사용자 권한"),
+	ADMIN("ROLE_ADMIN", "관리자 권한"),
+	GUEST("GUEST", "게스트 권한");
+
+	private final String code;
+	private final String displayName;
+
+	public static RoleType of(String code) {
+		return Arrays.stream(RoleType.values())
+			.filter(r -> r.getCode().equals(code))
+			.findAny()
+			.orElse(GUEST);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/entity/UserPrincipal.java
+++ b/src/main/java/com/checkmate/backend/oauth/entity/UserPrincipal.java
@@ -1,0 +1,114 @@
+package com.checkmate.backend.oauth.entity;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.checkmate.backend.oauth.api.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @package : com.checkmate.backend.oauth.entity
+ * @name: UserPrincipal.java
+ * @date : 2022/05/22 6:20 오후
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : Spring Security에서 소셜 로그인 / 로컬 로그인 정보 담고있음
+ * @modified :
+ **/
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class UserPrincipal implements OAuth2User, UserDetails, OidcUser {
+	private final String userId;
+	private final String password;
+	private final ProviderType providerType;
+	private final RoleType roleType;
+	private final Collection<GrantedAuthority> authorities;
+	private Map<String, Object> attributes;
+
+	public static UserPrincipal create(User user) {
+		return new UserPrincipal(
+			user.getUserId(),
+			user.getPassword(),
+			user.getProviderType(),
+			RoleType.USER,
+			Collections.singletonList(new SimpleGrantedAuthority(RoleType.USER.getCode()))
+		);
+	}
+
+	public static UserPrincipal create(User user, Map<String, Object> attributes) {
+		UserPrincipal userPrincipal = create(user);
+		userPrincipal.setAttributes(attributes);
+
+		return userPrincipal;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getName() {
+		return userId;
+	}
+
+	@Override
+	public String getUsername() {
+		return userId;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	@Override
+	public Map<String, Object> getClaims() {
+		return null;
+	}
+
+	@Override
+	public OidcUserInfo getUserInfo() {
+		return null;
+	}
+
+	@Override
+	public OidcIdToken getIdToken() {
+		return null;
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/checkmate/backend/oauth/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.checkmate.backend.oauth.filter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.checkmate.backend.oauth.token.AuthToken;
+import com.checkmate.backend.oauth.token.AuthTokenProvider;
+import com.checkmate.backend.oauth.util.HeaderUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @package : com.checkmate.backend.oauth.filter
+ * @name: TokenAuthenticationFilter.java
+ * @date : 2022/05/22 5:38 오후
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : Generating Token / Validating JWT 과정에서 첫번째 필터 OncePerRequestFilter -> 토큰을 가지고 있는지 체크
+ * @modified :
+ **/
+@Slf4j
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+	private final AuthTokenProvider tokenProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String tokenStr = HeaderUtil.getAccessToken(request);
+		AuthToken token = tokenProvider.convertAuthToken(tokenStr);
+
+		if (token.validate()) {
+			Authentication authentication = tokenProvider.getAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		filterChain.doFilter(request, response);
+
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/checkmate/backend/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,55 @@
+package com.checkmate.backend.oauth.handler;
+
+import static com.checkmate.backend.oauth.api.repo.OAuth2AuthorizationRequestBasedOnCookieRepository.*;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.checkmate.backend.oauth.api.repo.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.checkmate.backend.oauth.util.CookieUtil;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : com.checkmate.backend.oauth.handler
+ * @name: OAuth2AuthenticationFailureHandler.java
+ * @date : 2022/05/23 1:26 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : OAuth2 authentication 수행중에 어떠한 error라도 발생하게되면, OAuth2AuthenticationFailureHandler가 invoke
+ * @modified :
+ **/
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	private final OAuth2AuthorizationRequestBasedOnCookieRepository authorizationRequestRepository;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws
+		IOException, ServletException {
+		String targetUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+			.map(Cookie::getValue)
+			.orElse(("/"));
+
+		exception.printStackTrace();
+
+		targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+			.queryParam("error", exception.getLocalizedMessage())
+			.build().toUriString();
+
+		authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/checkmate/backend/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,159 @@
+package com.checkmate.backend.oauth.handler;
+
+import static com.checkmate.backend.oauth.api.repo.OAuth2AuthorizationRequestBasedOnCookieRepository.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Optional;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.checkmate.backend.oauth.api.entity.UserRefreshToken;
+import com.checkmate.backend.oauth.api.repo.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.checkmate.backend.oauth.api.repo.UserRefreshTokenRepository;
+import com.checkmate.backend.oauth.config.AppProperties;
+import com.checkmate.backend.oauth.entity.ProviderType;
+import com.checkmate.backend.oauth.entity.RoleType;
+import com.checkmate.backend.oauth.info.OAuth2UserInfo;
+import com.checkmate.backend.oauth.info.OAuth2UserInfoFactory;
+import com.checkmate.backend.oauth.token.AuthToken;
+import com.checkmate.backend.oauth.token.AuthTokenProvider;
+import com.checkmate.backend.oauth.util.CookieUtil;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : com.checkmate.backend.oauth.handler
+ * @name: OAuth2AuthenticationFailureHandler.java
+ * @date : 2022/05/23 1:29 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : OAuth2AuthenticationSuccessHandler는 login 성공시 invoked
+ * @modified :
+ **/
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final AuthTokenProvider tokenProvider;
+	private final AppProperties appProperties;
+	private final UserRefreshTokenRepository userRefreshTokenRepository;
+	private final OAuth2AuthorizationRequestBasedOnCookieRepository authorizationRequestRepository;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws
+		IOException, ServletException {
+		String targetUrl = determineTargetUrl(request, response, authentication);
+
+		if (response.isCommitted()) {
+			logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+			return;
+		}
+
+		clearAuthenticationAttributes(request, response);
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+
+	protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) {
+		Optional<String> redirectUri = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+			.map(Cookie::getValue);
+
+		if (redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
+			throw new IllegalArgumentException(
+				"Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication");
+		}
+
+		String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
+
+		OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken)authentication;
+		ProviderType providerType = ProviderType.valueOf(authToken.getAuthorizedClientRegistrationId().toUpperCase());
+
+		OidcUser user = ((OidcUser)authentication.getPrincipal());
+		OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, user.getAttributes());
+		Collection<? extends GrantedAuthority> authorities = ((OidcUser)authentication.getPrincipal()).getAuthorities();
+
+		RoleType roleType = hasAuthority(authorities, RoleType.ADMIN.getCode()) ? RoleType.ADMIN : RoleType.USER;
+
+		Date now = new Date();
+		AuthToken accessToken = tokenProvider.createAuthToken(
+			userInfo.getId(),
+			roleType.getCode(),
+			new Date(now.getTime() + appProperties.getAuth().getTokenExpiry())
+		);
+
+		// refresh 토큰 설정
+		long refreshTokenExpiry = appProperties.getAuth().getRefreshTokenExpiry();
+
+		AuthToken refreshToken = tokenProvider.createAuthToken(
+			appProperties.getAuth().getTokenSecret(),
+			new Date(now.getTime() + refreshTokenExpiry)
+		);
+
+		// DB 저장
+		UserRefreshToken userRefreshToken = userRefreshTokenRepository.findByUserId(userInfo.getId());
+		if (userRefreshToken != null) {
+			userRefreshToken.setRefreshToken(refreshToken.getToken());
+		} else {
+			userRefreshToken = new UserRefreshToken(userInfo.getId(), refreshToken.getToken());
+			userRefreshTokenRepository.saveAndFlush(userRefreshToken);
+		}
+
+		int cookieMaxAge = (int)refreshTokenExpiry / 60;
+
+		CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+		CookieUtil.addCookie(response, REFRESH_TOKEN, refreshToken.getToken(), cookieMaxAge);
+
+		return UriComponentsBuilder.fromUriString(targetUrl)
+			.queryParam("token", accessToken.getToken())
+			.build().toUriString();
+	}
+
+	protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+		super.clearAuthenticationAttributes(request);
+		authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+	}
+
+	private boolean hasAuthority(Collection<? extends GrantedAuthority> authorities, String authority) {
+		if (authorities == null) {
+			return false;
+		}
+
+		for (GrantedAuthority grantedAuthority : authorities) {
+			if (authority.equals(grantedAuthority.getAuthority())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isAuthorizedRedirectUri(String uri) {
+		URI clientRedirectUri = URI.create(uri);
+
+		return appProperties.getOauth2().getAuthorizedRedirectUris()
+			.stream()
+			.anyMatch(authorizedRedirectUri -> {
+				// Only validate host and port. Let the clients use different paths if they want to
+				URI authorizedURI = URI.create(authorizedRedirectUri);
+				if (authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+					&& authorizedURI.getPort() == clientRedirectUri.getPort()) {
+					return true;
+				}
+				return false;
+			});
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/handler/TokenAccessDeniedHandler.java
+++ b/src/main/java/com/checkmate/backend/oauth/handler/TokenAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.checkmate.backend.oauth.handler;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : com.checkmate.backend.oauth.handler
+ * @name: TokenAccessDeniedHandler.java
+ * @date : 2022/05/22 5:43 오후
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 인가되지 않은 사용자 관한 처리
+ * @modified :
+ **/
+@Component
+@RequiredArgsConstructor
+public class TokenAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final HandlerExceptionResolver handlerExceptionResolver;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws
+		IOException {
+		//response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+		handlerExceptionResolver.resolveException(request, response, null, accessDeniedException);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/info/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/checkmate/backend/oauth/info/GoogleOAuth2UserInfo.java
@@ -1,0 +1,26 @@
+package com.checkmate.backend.oauth.info;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+	public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+		super(attributes);
+	}
+
+	@Override
+	public String getId() {
+		return (String)attributes.get("sub");
+	}
+
+	@Override
+	public String getName() {
+		return (String)attributes.get("name");
+	}
+
+	@Override
+	public String getEmail() {
+		return (String)attributes.get("email");
+	}
+
+}

--- a/src/main/java/com/checkmate/backend/oauth/info/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/checkmate/backend/oauth/info/KakaoOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.checkmate.backend.oauth.info;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+	public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+		super(attributes);
+	}
+
+	@Override
+	public String getId() {
+		return attributes.get("id").toString();
+	}
+
+	@Override
+	public String getName() {
+		Map<String, Object> properties = (Map<String, Object>)attributes.get("properties");
+
+		if (properties == null) {
+			return null;
+		}
+
+		return (String)properties.get("nickname");
+	}
+
+	@Override
+	public String getEmail() {
+		return (String)attributes.get("account_email");
+	}
+
+}

--- a/src/main/java/com/checkmate/backend/oauth/info/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/checkmate/backend/oauth/info/NaverOAuth2UserInfo.java
@@ -1,0 +1,43 @@
+package com.checkmate.backend.oauth.info;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+	public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+		super(attributes);
+	}
+
+	@Override
+	public String getId() {
+		Map<String, Object> response = (Map<String, Object>)attributes.get("response");
+
+		if (response == null) {
+			return null;
+		}
+
+		return (String)response.get("id");
+	}
+
+	@Override
+	public String getName() {
+		Map<String, Object> response = (Map<String, Object>)attributes.get("response");
+
+		if (response == null) {
+			return null;
+		}
+
+		return (String)response.get("nickname");
+	}
+
+	@Override
+	public String getEmail() {
+		Map<String, Object> response = (Map<String, Object>)attributes.get("response");
+
+		if (response == null) {
+			return null;
+		}
+
+		return (String)response.get("email");
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/info/OAuth2UserInfo.java
+++ b/src/main/java/com/checkmate/backend/oauth/info/OAuth2UserInfo.java
@@ -1,0 +1,31 @@
+package com.checkmate.backend.oauth.info;
+
+import java.util.Map;
+
+/**
+ * @package : com.checkmate.backend.oauth.info
+ * @name: OAuth2UserInfo.java
+ * @date : 2022/05/23 12:59 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description :
+ * @modified :
+ **/
+public abstract class OAuth2UserInfo {
+	protected Map<String, Object> attributes;
+
+	public OAuth2UserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	public abstract String getId();
+
+	public abstract String getName();
+
+	public abstract String getEmail();
+
+}

--- a/src/main/java/com/checkmate/backend/oauth/info/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/checkmate/backend/oauth/info/OAuth2UserInfoFactory.java
@@ -1,0 +1,29 @@
+package com.checkmate.backend.oauth.info;
+
+import java.util.Map;
+
+import com.checkmate.backend.oauth.entity.ProviderType;
+
+/**
+ * @package : com.checkmate.backend.oauth.info
+ * @name: OAuth2UserInfoFactory.java
+ * @date : 2022/05/23 12:59 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : ProviderType에 따라 UserInfo 나눔
+ * @modified :
+ **/
+public class OAuth2UserInfoFactory {
+	public static OAuth2UserInfo getOAuth2UserInfo(ProviderType providerType, Map<String, Object> attributes) {
+		switch (providerType) {
+			case GOOGLE:
+				return new GoogleOAuth2UserInfo(attributes);
+			case NAVER:
+				return new NaverOAuth2UserInfo(attributes);
+			case KAKAO:
+				return new KakaoOAuth2UserInfo(attributes);
+			default:
+				throw new IllegalArgumentException("Invalid Provider Type.");
+		}
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/model/AuthReqModel.java
+++ b/src/main/java/com/checkmate/backend/oauth/model/AuthReqModel.java
@@ -1,0 +1,15 @@
+package com.checkmate.backend.oauth.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthReqModel {
+	private String id;
+	private String password;
+}

--- a/src/main/java/com/checkmate/backend/oauth/model/UserDto.java
+++ b/src/main/java/com/checkmate/backend/oauth/model/UserDto.java
@@ -1,0 +1,22 @@
+package com.checkmate.backend.oauth.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Builder
+public class UserDto {
+
+	private String userId;
+
+	private String username;
+
+	private String password;
+
+}

--- a/src/main/java/com/checkmate/backend/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/checkmate/backend/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,100 @@
+package com.checkmate.backend.oauth.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.checkmate.backend.advice.exception.OAuthProviderMissMatchException;
+import com.checkmate.backend.oauth.api.entity.User;
+import com.checkmate.backend.oauth.api.repo.UserRepository;
+import com.checkmate.backend.oauth.entity.ProviderType;
+import com.checkmate.backend.oauth.entity.RoleType;
+import com.checkmate.backend.oauth.entity.UserPrincipal;
+import com.checkmate.backend.oauth.info.OAuth2UserInfo;
+import com.checkmate.backend.oauth.info.OAuth2UserInfoFactory;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : com.checkmate.backend.oauth.service
+ * @name: CustomOAuth2UserService.java
+ * @date : 2022/05/22 6:24 오후
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 소셜로그인 처리하는 Service
+ * @modified :
+ **/
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User user = super.loadUser(userRequest);
+
+		try {
+			return this.process(userRequest, user);
+		} catch (AuthenticationException ex) {
+			throw ex;
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+		}
+	}
+
+	private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User user) {
+		// naver google kakao 구분 짓는 코드
+		ProviderType providerType = ProviderType.valueOf(
+			userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+
+		OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, user.getAttributes());
+		// 회원가입 된 User 정보 찾음
+		User savedUser = userRepository.findByUserId(userInfo.getId());
+
+		if (savedUser != null) {//회원가입 o
+			if (providerType != savedUser.getProviderType()) {
+				throw new OAuthProviderMissMatchException(
+					"Looks like you're signed up with " + providerType +
+						" account. Please use your " + savedUser.getProviderType() + " account to login."
+				);
+			}
+			updateUser(savedUser, userInfo);
+		} else {//회원가입 x
+			savedUser = createUser(userInfo, providerType);
+		}
+
+		return UserPrincipal.create(savedUser, user.getAttributes());
+	}
+
+	//첫 로그인시 회원가입
+	private User createUser(OAuth2UserInfo userInfo, ProviderType providerType) {
+		LocalDateTime now = LocalDateTime.now();
+		User user = new User(
+			userInfo.getId(),
+			userInfo.getName(),
+			"No_Password",
+			providerType,
+			RoleType.USER,
+			now,
+			now
+		);
+
+		return userRepository.saveAndFlush(user);
+	}
+
+	private User updateUser(User user, OAuth2UserInfo userInfo) {
+		if (userInfo.getName() != null && !user.getUsername().equals(userInfo.getName())) {
+			user.setUsername(userInfo.getName());
+		}
+
+		return user;
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/service/CustomUserDetailService.java
+++ b/src/main/java/com/checkmate/backend/oauth/service/CustomUserDetailService.java
@@ -1,0 +1,37 @@
+package com.checkmate.backend.oauth.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.checkmate.backend.oauth.api.entity.User;
+import com.checkmate.backend.oauth.api.repo.UserRepository;
+import com.checkmate.backend.oauth.entity.UserPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : com.checkmate.backend.oauth.service
+ * @name: CustomUserDetailService.java
+ * @date : 2022/05/23 1:26 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : local 로그인을 위함 유저의 정보를 가져옴
+ * @modified :
+ **/
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findByUserId(username);
+		if (user == null) {
+			throw new UsernameNotFoundException("Can not find username.");
+		}
+		return UserPrincipal.create(user);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/service/UserService.java
+++ b/src/main/java/com/checkmate/backend/oauth/service/UserService.java
@@ -1,0 +1,39 @@
+package com.checkmate.backend.oauth.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.checkmate.backend.oauth.api.entity.User;
+import com.checkmate.backend.oauth.api.repo.UserRepository;
+import com.checkmate.backend.oauth.entity.ProviderType;
+import com.checkmate.backend.oauth.entity.RoleType;
+import com.checkmate.backend.oauth.model.UserDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public User getUser(String userId) {
+		return userRepository.findByUserId(userId);
+	}
+
+	public User signUpUser(UserDto user) {
+		LocalDateTime now = LocalDateTime.now();
+		User u = new User(
+			user.getUserId(),
+			user.getUsername(),
+			passwordEncoder.encode(user.getPassword()),
+			ProviderType.LOCAL,
+			RoleType.USER,
+			now,
+			now
+		);
+		return userRepository.save(u);
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/token/AuthToken.java
+++ b/src/main/java/com/checkmate/backend/oauth/token/AuthToken.java
@@ -1,0 +1,101 @@
+package com.checkmate.backend.oauth.token;
+
+import java.security.Key;
+import java.util.Date;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @package : com.checkmate.backend.oauth.token
+ * @name: AuthToken.java
+ * @date : 2022/05/22 5:13 오후
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : Jwt 패키지를 생성, 토큰 생성과 토큰의 유효성 검증 담당
+ * @modified :
+ **/
+@Slf4j
+@RequiredArgsConstructor
+public class AuthToken {
+
+	private static final String AUTHORITIES_KEY = "role";
+	@Getter
+	private final String token;
+	private final Key key;
+
+	AuthToken(String id, Date expiry, Key key) {
+		this.key = key;
+		this.token = createAuthToken(id, expiry);
+	}
+
+	AuthToken(String id, String role, Date expiry, Key key) {
+		this.key = key;
+		this.token = createAuthToken(id, role, expiry);
+	}
+
+	//토큰 생성
+	private String createAuthToken(String id, Date expiry) {
+		return Jwts.builder()
+			.setSubject(id)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.setExpiration(expiry)
+			.compact();
+	}
+
+	private String createAuthToken(String id, String role, Date expiry) {
+		return Jwts.builder()
+			.setSubject(id)
+			.claim(AUTHORITIES_KEY, role)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.setExpiration(expiry)
+			.compact();
+	}
+
+	public boolean validate() {
+		return this.getTokenClaims() != null;
+	}
+
+	public Claims getTokenClaims() {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (SecurityException e) {
+			log.info("Invalid JWT signature.");
+		} catch (MalformedJwtException e) {
+			log.info("Invalid JWT token.");
+		} catch (ExpiredJwtException e) {
+			log.info("Expired JWT token.");
+		} catch (UnsupportedJwtException e) {
+			log.info("Unsupported JWT token.");
+		} catch (IllegalArgumentException e) {
+			log.info("JWT token compact of handler are invalid.");
+		}
+		return null;
+	}
+
+	public Claims getExpiredTokenClaims() {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			log.info("expired JWT token.");
+			return e.getClaims();
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/checkmate/backend/oauth/token/AuthTokenProvider.java
+++ b/src/main/java/com/checkmate/backend/oauth/token/AuthTokenProvider.java
@@ -1,0 +1,64 @@
+package com.checkmate.backend.oauth.token;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import com.checkmate.backend.advice.exception.TokenValidFailedException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AuthTokenProvider {
+
+	private static final String AUTHORITIES_KEY = "role";
+	private final Key key;
+
+	public AuthTokenProvider(String secret) {
+		// 스트링인 yml 파일의 secret키를 인코딩 된 byte 배열로 변환후 다시 SecretKey로 변환해 주는 hmacShaKeyFor
+		this.key = Keys.hmacShaKeyFor(secret.getBytes());
+	}
+
+	public AuthToken createAuthToken(String id, Date expiry) {
+		return new AuthToken(id, expiry, key);
+	}
+
+	public AuthToken createAuthToken(String id, String role, Date expiry) {
+		return new AuthToken(id, role, expiry, key);
+	}
+
+	public AuthToken convertAuthToken(String token) {
+		return new AuthToken(token, key);
+	}
+
+	// token 값에서 사용자의 정보를 꺼내는 함수
+	public Authentication getAuthentication(AuthToken authToken) {
+
+		if (authToken.validate()) {
+
+			Claims claims = authToken.getTokenClaims();
+			Collection<? extends GrantedAuthority> authorities =
+				Arrays.stream(new String[] {claims.get(AUTHORITIES_KEY).toString()})
+					.map(SimpleGrantedAuthority::new)
+					.collect(Collectors.toList());
+
+			log.debug("claims subject := [{}]", claims.getSubject());
+			User principal = new User(claims.getSubject(), "", authorities);
+
+			return new UsernamePasswordAuthenticationToken(principal, authToken, authorities);
+		} else {
+			throw new TokenValidFailedException();
+		}
+	}
+
+}

--- a/src/main/java/com/checkmate/backend/oauth/util/CookieUtil.java
+++ b/src/main/java/com/checkmate/backend/oauth/util/CookieUtil.java
@@ -1,0 +1,64 @@
+package com.checkmate.backend.oauth.util;
+
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.SerializationUtils;
+
+public class CookieUtil {
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (name.equals(cookie.getName())) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(maxAge);
+
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+		Cookie[] cookies = request.getCookies();
+
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (name.equals(cookie.getName())) {
+					cookie.setValue("");
+					cookie.setPath("/");
+					cookie.setMaxAge(0);
+					response.addCookie(cookie);
+				}
+			}
+		}
+	}
+
+	public static String serialize(Object obj) {
+		return Base64.getUrlEncoder()
+			.encodeToString(SerializationUtils.serialize(obj));
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		return cls.cast(
+			SerializationUtils.deserialize(
+				Base64.getUrlDecoder().decode(cookie.getValue())
+			)
+		);
+	}
+
+}

--- a/src/main/java/com/checkmate/backend/oauth/util/HeaderUtil.java
+++ b/src/main/java/com/checkmate/backend/oauth/util/HeaderUtil.java
@@ -1,0 +1,23 @@
+package com.checkmate.backend.oauth.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class HeaderUtil {
+
+	private final static String HEADER_AUTHORIZATION = "Authorization";
+	private final static String TOKEN_PREFIX = "Bearer ";
+
+	public static String getAccessToken(HttpServletRequest request) {
+		String headerValue = request.getHeader(HEADER_AUTHORIZATION);
+
+		if (headerValue == null) {
+			return null;
+		}
+
+		if (headerValue.startsWith(TOKEN_PREFIX)) {
+			return headerValue.substring(TOKEN_PREFIX.length());
+		}
+
+		return null;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,86 @@
-S
+spring:
+  profiles.active: local
+  # h2 설정
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+      path: /h2-console
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:~/test
+    username: sa
+    password:
+  #JPA 설정
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+  # Security OAuth
+  security:
+    oauth2.client:
+      registration:
+        google:
+          clientId: '1071630330351-r4vn1l7e3vtf90oke3odutv976of1868.apps.googleusercontent.com'
+          clientSecret: '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'
+          scope:
+            - email
+            - profile
+        naver:
+          clientId: 'beUJSLfYYCAuVlUBggkQ'
+          clientSecret: 'hnIQcBaEma'
+          clientAuthenticationMethod: post
+          authorizationGrantType: authorization_code
+          redirectUri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
+          scope:
+            - nickname
+            - email
+          clientName: Naver
+        kakao:
+          clientId: '1708a2abcd2c33aeea0e8bdfd5d4c8be'
+          clientSecret: 'b2T1kkyQedKoLQ6uOC2rEsEGCGF8M1bZ'
+          clientAuthenticationMethod: post
+          authorizationGrantType: authorization_code
+          redirectUri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
+          scope:
+            - profile_nickname
+            - account_email
+          clientName: Kakao
+      # Provider 설정
+      provider:
+        naver:
+          authorizationUri: https://nid.naver.com/oauth2.0/authorize
+          tokenUri: https://nid.naver.com/oauth2.0/token
+          userInfoUri: https://openapi.naver.com/v1/nid/me
+          userNameAttribute: response
+        kakao:
+          authorizationUri: https://kauth.kakao.com/oauth/authorize
+          tokenUri: https://kauth.kakao.com/oauth/token
+          userInfoUri: https://kapi.kakao.com/v2/user/me
+          userNameAttribute: id
+
+# cors 설정
+cors:
+  allowed-origins: 'http://localhost:3000'
+  allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+  allowed-headers: '*'
+  max-age: 3600
+
+# jwt secret key 설정
+jwt.secret: 8sknjlO3NPTBqo319DHLNqsQAfRJEdKsETOds
+
+# 토큰 관련 secret Key 및 RedirectUri 설정
+app:
+  auth:
+    tokenSecret: 926D96C90030DD58429D2751AC1BDBBC
+    tokenExpiry: 1800000
+    refreshTokenExpiry: 604800000
+  oauth2:
+    authorizedRedirectUris:
+      - http://localhost:3000/oauth/redirect
+
+logging:
+  level:
+    org.springframework.security: TRACE


### PR DESCRIPTION
# 로그인 회원가입
![image](https://user-images.githubusercontent.com/62784314/170077360-a6ac48b2-3849-4e3d-95aa-1b035ceff58c.png)
## 1. /api/v1/users/join
Local Member 회원가입
## 2. /api/v1/users
헤더에 있는 토큰값을 이용해 유저 정보를 조회
## 3. /api/v1/auth/login
소셜로그인과 Local 로그인 통합
## 4. /api/v1/auth/refresh
refresh Token 재 발급

## 기타 사항
1. 테스트 진행중입니다.
2. Spring security 설정 부분 변경 필요( 현재 테스트 환경 )

### Swagger 쓰는 방법
1. 로그인하기 -> 토큰 값 얻기
![image](https://user-images.githubusercontent.com/62784314/170078223-8b72c57e-2eee-48cf-8190-1fc0d4616aff.png)
4. 이 버튼 클릭 -> 토큰 값 입력 = 헤더값이 들어가있는 상태로 테스트 가능
![image](https://user-images.githubusercontent.com/62784314/170078293-fea4bbc7-7b11-4fde-b6ea-c21a1faa6202.png)


블로그 정리(https://velog.io/@jifrozen/Checkmate-OAuth2-소셜-로그인구글-카카오-네이버-로그인-회원가입)